### PR TITLE
用户id更改为string. 根据积分计算等级,   每天做一件事有额外奖励

### DIFF
--- a/MeritBehavior.php
+++ b/MeritBehavior.php
@@ -122,6 +122,7 @@ class MeritBehavior extends Behavior
             if(!$m)
             {
                 $m = new Continuous;
+                $m->user_id  = $user_id;
             }
 
             $count = $m->count;

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,10 @@
         {
             "name": "forecho",
             "email": "caizhenghai@gmail.com"
+        },
+        {
+            "name": "soul11201",
+            "email": "soul11201@gmail.com"
         }
     ],
     "require": {

--- a/migrations/m160320_093621_create_merit_table.php
+++ b/migrations/m160320_093621_create_merit_table.php
@@ -50,7 +50,7 @@ class m160320_093621_create_merit_table extends Migration
 
         $this->createTable('{{%merit}}', [
             'id' => Schema::TYPE_PK,
-            'user_id' => Schema::TYPE_INTEGER . " UNSIGNED DEFAULT NULL COMMENT '用户ID'",
+            'user_id' => $this->string(100)->notNull()->defaultValue('')->comment('用户ID') ,
             'username' => Schema::TYPE_STRING . "(20) DEFAULT NULL COMMENT '用户名'",
             'type' => Schema::TYPE_INTEGER . "(2) DEFAULT 1 COMMENT '类型 1:积分 2:声望 3:徽章'",
             'merit' => Schema::TYPE_INTEGER . " DEFAULT NULL COMMENT '总值'",
@@ -62,7 +62,7 @@ class m160320_093621_create_merit_table extends Migration
 
         $this->createTable('{{%merit_log}}', [
             'id' => Schema::TYPE_PK,
-            'user_id' => Schema::TYPE_INTEGER . " UNSIGNED NULL NULL COMMENT '用户ID'",
+            'user_id' => $this->string(100)->notNull()->defaultValue('')->comment('用户ID') ,
             'username' => Schema::TYPE_STRING . "(20) DEFAULT NULL COMMENT '用户名'",
             'merit_template_id' => Schema::TYPE_INTEGER . " UNSIGNED NULL NULL COMMENT '模板ID'",
             'type' => Schema::TYPE_INTEGER . "(2) DEFAULT 1 COMMENT '类型 1:积分 2:声望 3:徽章'",

--- a/migrations/m170710_030015_add_level.php
+++ b/migrations/m170710_030015_add_level.php
@@ -1,0 +1,44 @@
+<?php
+
+use yii\db\Migration;
+
+class m170710_030015_add_level extends Migration
+{
+    public function safeUp()
+    {
+        $this->addColumn('{{%merit}}','level',
+            $this->integer()
+                ->notNull()
+                ->defaultValue(0)
+                ->comment("根据总积分、正值累积积分计算出来的用户等级")
+        );
+        $this->addColumn('{{%merit}}','pos_accu_merit',
+            $this->integer()
+                ->notNull()
+                ->defaultValue(0)
+                ->comment("正值累积积分")
+        );
+    }
+
+    public function safeDown()
+    {
+        echo "m170710_030015_add_level cannot be reverted.\n";
+
+        return false;
+    }
+
+    /*
+    // Use up()/down() to run migration code without a transaction.
+    public function up()
+    {
+
+    }
+
+    public function down()
+    {
+        echo "m170710_030015_add_level cannot be reverted.\n";
+
+        return false;
+    }
+    */
+}

--- a/migrations/m170710_030015_add_level.php
+++ b/migrations/m170710_030015_add_level.php
@@ -23,7 +23,8 @@ class m170710_030015_add_level extends Migration
     public function safeDown()
     {
         echo "m170710_030015_add_level cannot be reverted.\n";
-
+        $this->dropColumn('{{%merit}}','level');
+        $this->dropColumn('{{%merit}}','pos_accu_merit');
         return false;
     }
 

--- a/migrations/m170713_091926_add_continus_events.php
+++ b/migrations/m170713_091926_add_continus_events.php
@@ -1,0 +1,71 @@
+<?php
+
+use yii\db\Migration;
+
+class m170713_091926_add_continus_events extends Migration
+{
+    /**
+     * 创建表选项
+     * @var string
+     */
+    public $tableOptions = null;
+
+    public function init()
+    {
+        parent::init();
+
+        if ($this->db->driverName === 'mysql') { //Mysql 表选项
+            $this->tableOptions = 'CHARACTER SET utf8 COLLATE utf8_general_ci ENGINE=InnoDB';
+        }
+    }
+
+    public function safeUp()
+    {
+        $this->addColumn('{{%merit_template}}', 'events_type',
+            $this->integer()
+                ->notNull()
+                ->defaultValue(0)
+                ->comment("0: 普通的 1：连续登陆有额外的奖励")
+        );
+
+        $this->addColumn('{{%merit_template}}', 'continuous_count',
+            $this->integer()
+                ->notNull()
+                ->defaultValue(0)
+                ->comment("获得额外积分，需要连续做的次数")
+        );
+
+        $this->createTable('{{%continuous}}', [
+            'user_id' => $this->string(100)->notNull()->defaultValue('')->comment('用户ID'),
+            'count' => $this->integer()->defaultValue(0)->notNull(),
+            'next_start' => $this->integer()->defaultValue(0)->notNull(),
+            'next_end' => $this->integer()->defaultValue(0)->notNull(),
+        ], $this->tableOptions);
+        $this->createIndex('user_id','{{%continuous}}', 'user_id');
+
+    }
+
+    public function safeDown()
+    {
+        echo "m170713_091926_add_continus_events cannot be reverted.\n";
+        $this->dropColumn('{{%merit_template}}', 'continuous_count');
+        $this->dropColumn('{{%merit_template}}', 'events_type');
+        $this->dropTable('{{%continuous}}');
+        return true;
+    }
+
+    /*
+    // Use up()/down() to run migration code without a transaction.
+    public function up()
+    {
+
+    }
+
+    public function down()
+    {
+        echo "m170713_091926_add_continus_events cannot be reverted.\n";
+
+        return false;
+    }
+    */
+}

--- a/models/Continuous.php
+++ b/models/Continuous.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: soul11201 <soul11201@gmail.com>
+ * Date: 2017/7/12
+ * Time: 16:25
+ */
+
+namespace yiier\merit\models;
+
+/**
+ * This is the model class for table "continuous".
+ *
+ * @property string $user_id
+ * @property integer $count
+ * @property integer $next_start
+ * @property integer $next_end
+ */
+class Continuous extends \yii\db\ActiveRecord
+{
+    public $range = 24 * 3600;
+    public function __construct(array $config = [])
+    {
+        parent::__construct($config);
+        $this->count = 0;
+        $this->next_start = 0;
+        $this->next_end = 0;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function tableName()
+    {
+        return 'continuous';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function rules()
+    {
+        return [
+            [['count', 'next_start', 'next_end'], 'integer'],
+            [['user_id'], 'string', 'max' => 100],
+        ];
+    }
+
+    public function calc_count()
+    {
+        $time = time();
+
+        //已累计
+        if($this->next_start > $time)
+        {
+            return $this->count;
+        }
+
+        // 连续登陆中间断开重新计数
+        if($this->next_end < $time)
+        {
+            $this->count = 0;
+        }
+
+        //重新计数初始化
+        if($this->count == 0)
+        {
+            $this->next_start    = strtotime(date('Y-m-d')." 00:00:00"); //今日凌晨
+            $this->next_end  =  $this->next_start + $this->range;
+        }
+
+        $this->next_start += $this->range;
+        $this->next_end  += $this->range;
+        ++ $this->count;
+
+        return $this->count;
+    }
+}
+

--- a/models/LevelCalc.php
+++ b/models/LevelCalc.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: soul11201 <soul11201@gmail.com>
+ * Date: 2017/7/10
+ * Time: 11:31
+ */
+
+namespace yiier\merit\models;
+
+
+class LevelCalc implements LevelCalcInterface
+{
+    const LEVEL0 = 0;
+    const LEVEL1 = 1;
+    const LEVEL2 = 2;
+    const LEVEL3 = 3;
+    const LEVEL4 = 4;
+    const LEVEL5 = 5;
+
+    private static  $_level_name = [
+        self::LEVEL0 => '潜水',
+        self::LEVEL1 => '冒泡',
+        self::LEVEL2 => '吐槽',
+        self::LEVEL3 => '活跃',
+        self::LEVEL4 => '唠叨',
+        self::LEVEL5 => '传说',
+    ];
+    private static $_jifen_level_map = [
+        1700 => self::LEVEL5,
+        1600 => self::LEVEL4,
+        1500 => self::LEVEL3,
+        1000 => self::LEVEL2,
+        500  => self::LEVEL1,
+        0    => self::LEVEL0,
+    ];
+
+    public function calc_level($merit, $pos_accu_merit)
+    {
+        foreach (self::$_jifen_level_map as $jifen_thresh_hold => $level)
+        {
+            if($merit >= $jifen_thresh_hold)
+            {
+                return $level;
+            }
+        }
+        return -1;
+    }
+
+    public function get_levelName($level)
+    {
+        return self::$_level_name[$level];
+    }
+}

--- a/models/LevelCalcInterface.php
+++ b/models/LevelCalcInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: soul11201 <soul11201@gmail.com>
+ * Date: 2017/7/10
+ * Time: 13:51
+ */
+
+namespace yiier\merit\models;
+
+
+interface LevelCalcInterface
+{
+    /**
+     *
+     *根据总积分、正值累积积分计算出来的用户等级
+     *
+     * @param integer $merit
+     * @param integer $pos_accu_merit
+     * @return integer the level result >=0 if -1 returned means maybe wrong
+     */
+    public function calc_level($merit, $pos_accu_merit);
+
+    /**
+     *
+     * 获取级别对应的级别名称
+     *
+     * @param integer $level
+     * @return string
+     */
+    public function get_levelName($level);
+}

--- a/models/Merit.php
+++ b/models/Merit.php
@@ -49,7 +49,8 @@ class Merit extends \yii\db\ActiveRecord
     public function rules()
     {
         return [
-            [['user_id', 'type', 'merit', 'created_at', 'updated_at'], 'integer'],
+            [['type', 'merit', 'created_at', 'updated_at'], 'integer'],
+            [['user_id'], 'string', 'max' => 100],
             [['username'], 'string', 'max' => 20]
         ];
     }

--- a/models/Merit.php
+++ b/models/Merit.php
@@ -19,6 +19,8 @@ use yii\behaviors\TimestampBehavior;
  * @property string $username
  * @property integer $type
  * @property integer $merit
+ * @property integer $pos_accu_merit
+ * @property integer $level
  * @property integer $created_at
  * @property integer $updated_at
  */
@@ -49,7 +51,7 @@ class Merit extends \yii\db\ActiveRecord
     public function rules()
     {
         return [
-            [['type', 'merit', 'created_at', 'updated_at'], 'integer'],
+            [['type', 'merit', 'created_at', 'updated_at', 'level', 'pos_accu_merit'], 'integer'],
             [['user_id'], 'string', 'max' => 100],
             [['username'], 'string', 'max' => 20]
         ];
@@ -68,6 +70,8 @@ class Merit extends \yii\db\ActiveRecord
             'merit' => Yii::t('app', '总值'),
             'created_at' => Yii::t('app', '创建时间'),
             'updated_at' => Yii::t('app', '更新时间'),
+            'level' => Yii::t('app', '用户等级'),
+            'pos_accu_merit' => Yii::t('app', '正累积积分'),
         ];
     }
 }

--- a/models/MeritLog.php
+++ b/models/MeritLog.php
@@ -38,7 +38,7 @@ class MeritLog extends \yii\db\ActiveRecord
     public function rules()
     {
         return [
-            [['user_id', 'merit_template_id', 'type', 'action_type', 'increment', 'created_at'], 'integer'],
+            [['merit_template_id', 'type', 'action_type', 'increment', 'created_at'], 'integer'],
             [['description'], 'required'],
             [['user_id'], 'string', 'max' => 100],
             [['username'], 'string', 'max' => 20],

--- a/models/MeritLog.php
+++ b/models/MeritLog.php
@@ -40,6 +40,7 @@ class MeritLog extends \yii\db\ActiveRecord
         return [
             [['user_id', 'merit_template_id', 'type', 'action_type', 'increment', 'created_at'], 'integer'],
             [['description'], 'required'],
+            [['user_id'], 'string', 'max' => 100],
             [['username'], 'string', 'max' => 20],
             [['description'], 'string', 'max' => 255]
         ];

--- a/models/MeritLogSearch.php
+++ b/models/MeritLogSearch.php
@@ -17,7 +17,8 @@ class MeritLogSearch extends MeritLog
     public function rules()
     {
         return [
-            [['id', 'user_id', 'merit_template_id', 'type', 'action_type', 'increment', 'created_at'], 'integer'],
+            [['id', 'merit_template_id', 'type', 'action_type', 'increment', 'created_at'], 'integer'],
+            [['user_id'], 'string', 'max' => 100],
             [['description', 'username'], 'safe'],
         ];
     }

--- a/models/MeritTemplate.php
+++ b/models/MeritTemplate.php
@@ -27,6 +27,8 @@ use yiier\merit\Module;
  * @property integer $status
  * @property integer $created_at
  * @property integer $updated_at
+ * @property integer events_type
+ * @property integer continuous_count
  */
 class MeritTemplate extends \yii\db\ActiveRecord
 {
@@ -55,6 +57,16 @@ class MeritTemplate extends \yii\db\ActiveRecord
     const ACTIVE_TYPE_ADD = 2;
 
     /**
+     * @var int 普通的事件，比如每天登陆送积分,此为默认类型
+     */
+    const EVENTS_TYPE_NORMAL = 0;
+
+    /**
+     * @var int 连续登陆事件类型
+     */
+    const EVENTS_TYPE_CONTINUOUS = 1;
+
+    /**
      * 自动更新created_at和updated_at时间
      * @return array
      */
@@ -79,7 +91,7 @@ class MeritTemplate extends \yii\db\ActiveRecord
     public function rules()
     {
         return [
-            [['type', 'method', 'event', 'action_type', 'rule_key', 'rule_value', 'increment', 'status', 'created_at', 'updated_at'], 'integer'],
+            [['type', 'method', 'event', 'action_type', 'rule_key', 'rule_value', 'increment', 'status', 'created_at', 'updated_at', 'events_type', 'continuous_count'], 'integer'],
             [['title', 'unique_id'], 'required'],
             [['title', 'unique_id'], 'string', 'max' => 255]
         ];
@@ -104,6 +116,8 @@ class MeritTemplate extends \yii\db\ActiveRecord
             'status' => Yii::t('app', '状态'),
             'created_at' => Yii::t('app', '创建时间'),
             'updated_at' => Yii::t('app', '更新时间'),
+            'events_type' => Yii::t('app', '事件类型'),
+            'continuous_count' => Yii::t('app', '持续次数')
         ];
     }
 
@@ -144,6 +158,14 @@ class MeritTemplate extends \yii\db\ActiveRecord
         return [
             self::STATUS_ACTIVE => '开启',
             self::STATUS_DELETE => '停用',
+        ];
+    }
+
+    public static function getEventsType()
+    {
+        return [
+            self::EVENTS_TYPE_NORMAL => '做一次，就有一次',
+            self::EVENTS_TYPE_CONTINUOUS => '连续做，送额外奖励',
         ];
     }
 }

--- a/models/MeritTemplateSearch.php
+++ b/models/MeritTemplateSearch.php
@@ -17,7 +17,7 @@ class MeritTemplateSearch extends MeritTemplate
     public function rules()
     {
         return [
-            [['id', 'type', 'method', 'event', 'action_type', 'rule_key', 'rule_value', 'increment', 'status', 'created_at', 'updated_at'], 'integer'],
+            [['id', 'type', 'method', 'event', 'action_type', 'rule_key', 'rule_value', 'increment', 'status', 'created_at', 'updated_at', 'events_type', 'continuous_count'], 'integer'],
             [['title', 'unique_id'], 'safe'],
         ];
     }
@@ -66,6 +66,8 @@ class MeritTemplateSearch extends MeritTemplate
             'status' => $this->status,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
+            'events_type' => $this->events_type,
+            'continuous_count' => $this->continuous_count,
         ]);
 
         $query->andFilterWhere(['like', 'title', $this->title])

--- a/views/merit-template/_form.php
+++ b/views/merit-template/_form.php
@@ -33,6 +33,10 @@ use yiier\merit\models\MeritTemplate;
 
     <?= $form->field($model, 'status')->dropDownList(MeritTemplate::getStatuses()) ?>
 
+    <?= $form->field($model, 'events_type')->dropDownList(MeritTemplate::getEventsType()) ?>
+
+    <?= $form->field($model,  'continuous_count')->textInput() ?>
+
     <div class="form-group">
         <?= Html::submitButton($model->isNewRecord ? Yii::t('app', 'Create') : Yii::t('app', 'Update'), ['class' => $model->isNewRecord ? 'btn btn-success' : 'btn btn-primary']) ?>
     </div>

--- a/views/merit-template/index.php
+++ b/views/merit-template/index.php
@@ -60,6 +60,13 @@ $this->params['breadcrumbs'][] = $this->title;
                     return MeritTemplate::getStatuses()[$data->status];
                 }
             ],
+            [
+                'attribute' => 'events_type',
+                'value' => function ($data) {
+                    return MeritTemplate::getEventsType()[$data->events_type];
+                }
+            ],
+            'continuous_count',
             'created_at:datetime',
             'updated_at:datetime',
 

--- a/views/merit-template/view.php
+++ b/views/merit-template/view.php
@@ -55,6 +55,13 @@ $this->params['breadcrumbs'][] = $this->title;
                 'attribute' => 'status',
                 'value' => MeritTemplate::getStatuses()[$model->status]
             ],
+            [
+                'attribute' => 'events_type',
+                'value' => function ($data) {
+                    return MeritTemplate::getEventsType()[$data->events_type];
+                }
+            ],
+            'continuous_count',
             'created_at:datetime',
             'updated_at:datetime',
         ],

--- a/views/merit/index.php
+++ b/views/merit/index.php
@@ -7,9 +7,11 @@ use yiier\merit\models\MeritTemplate;
 /* @var $this yii\web\View */
 /* @var $searchModel yiier\merit\models\MeritSearch */
 /* @var $dataProvider yii\data\ActiveDataProvider */
+/* @var $levelCalc \yiier\merit\models\LevelCalcInterface*/
 
 $this->title = Yii::t('app', 'Merits');
 $this->params['breadcrumbs'][] = $this->title;
+$levelCalc =  \yii\di\Instance::ensure(Yii::$app->params['yiier\merit\models\LevelCalc']);
 ?>
 <div class="merit-index">
 
@@ -30,6 +32,15 @@ $this->params['breadcrumbs'][] = $this->title;
                 }
             ],
             'merit',
+            'pos_accu_merit',
+            'level',
+            [
+                'attribute' => 'level',
+                'label' => '等级名称',
+                'value' => function ($data) use ($levelCalc) {
+                    return $levelCalc->get_levelName($data->level);
+                }
+            ],
             'created_at:datetime',
             'updated_at:datetime',
 


### PR DESCRIPTION
user_id 改为string ，兼容跟多情况。
根据积分计算等级，根据累积的正值积分，或者总积分来计算等级。
具体的计算规则可以更改，只需配置 params `'yiier\merit\models\LevelCalc' => '扩展的类名'`如不配置默认使用，总积分来计算等级。